### PR TITLE
Add item check

### DIFF
--- a/src/rg-ctf-utils.ts
+++ b/src/rg-ctf-utils.ts
@@ -214,12 +214,14 @@ export default class RGCTFUtils {
       const item = bot.getItemDefinitionById(
         (collected.metadata[8] as any).itemId
       );
-      this.logDebug(
-        `Player ${collector.username} collected: ${
-          item.name
-        } at: ${bot.vecToString(collected.position)}`
-      );
-      this.bot.emit(CTFEvent.ITEM_COLLECTED, collector, item);
+      if (item) {
+        this.logDebug(
+          `Player ${collector.username} collected: ${
+            item.name
+          } at: ${bot.vecToString(collected.position)}`
+        );
+        this.bot.emit(CTFEvent.ITEM_COLLECTED, collector, item);
+      }
     });
 
     /**


### PR DESCRIPTION
Fixes a bug where if you pick up an arrow it throws an error because the item is undefined